### PR TITLE
Return 404 for actions on deleted arguments/replies https://github.com/citizenos/citizenos-api/issues/27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2019-01-09
+
+* Update topic argument reply, vote, report endpoints to return 404 when performing actions on deleted arguments/replies
+
 ## 2019-01-04
 
 * Add endpoints to read attachment json or download uploaded attachment file with proper filename by adding query parameter `?download=true`


### PR DESCRIPTION
Though deleted arguments are returned by API, actions on them should be prohibited. So 404 is returned to actions on deleted arguments