### PR TITLE
Make external authentication optional

### DIFF
--- a/app.js
+++ b/app.js
@@ -219,27 +219,33 @@ app.set('cosJwt', require('./libs/cosJwt')(app));
 app.set('cosUpload', require('./libs/cosUpload')(app));
 
 //Config smartId
-const smartId = require('smart-id-rest')();
-smartId.init({
-    hostname: config.services.smartId.hostname,
-    apiPath: config.services.smartId.apiPath,
-    authorizeToken: config.services.smartId.authorizeToken,
-    relyingPartyUUID: config.services.smartId.relyingPartyUUID,
-    replyingPartyName: config.services.smartId.replyingPartyName,
-    issuers: config.services.signature.certificates.issuers
-});
-app.set('smartId', smartId);
+if (config.services.smartId) {
+    const smartId = require('smart-id-rest')();
+    smartId.init({
+        hostname: config.services.smartId.hostname,
+        apiPath: config.services.smartId.apiPath,
+        authorizeToken: config.services.smartId.authorizeToken,
+        relyingPartyUUID: config.services.smartId.relyingPartyUUID,
+        replyingPartyName: config.services.smartId.replyingPartyName,
+        issuers: config.services.signature.certificates.issuers
+    });
+    app.set('smartId', smartId);
+}
+
 //Config mobiilId
-const mobileId = require('mobiil-id-rest')();
-mobileId.init({
-    hostname: config.services.mobileId.hostname,
-    apiPath: config.services.mobileId.apiPath,
-    authorizeToken: config.services.mobileId.authorizeToken,
-    relyingPartyUUID: config.services.mobileId.relyingPartyUUID,
-    replyingPartyName: config.services.mobileId.replyingPartyName,
-    issuers: config.services.signature.certificates.issuers
-});
-app.set('mobileId', mobileId);
+if (config.services.mobileId) {
+    const mobileId = require('mobiil-id-rest')();
+    mobileId.init({
+        hostname: config.services.mobileId.hostname,
+        apiPath: config.services.mobileId.apiPath,
+        authorizeToken: config.services.mobileId.authorizeToken,
+        relyingPartyUUID: config.services.mobileId.relyingPartyUUID,
+        replyingPartyName: config.services.mobileId.replyingPartyName,
+        issuers: config.services.signature.certificates.issuers
+    });
+    app.set('mobileId', mobileId);
+}
+
 app.set('cosSignature', require('./libs/cosSignature')(app));
 
 if (typeof config.email === 'string') {

--- a/libs/passport/index.js
+++ b/libs/passport/index.js
@@ -141,50 +141,54 @@ module.exports = function (app) {
         });
 
         // GOOGLE
-        passport.use(new GoogleStrategy(
-            {
-                clientID: config.passport.google.clientId,
-                clientSecret: config.passport.google.clientSecret,
-                callbackURL: urlLib.getApi(config.passport.google.callbackUrl),
-                userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
-                passReqToCallback: true // http://passportjs.org/guide/authorize/#association_in_verify_callback
-            },
-            async function (req, accessToken, refreshToken, profile, done) {
-                logger.debug('Google responded with profile: ', profile);
+	if (passport.google) {
+            passport.use(new GoogleStrategy(
+                {
+                    clientID: config.passport.google.clientId,
+                    clientSecret: config.passport.google.clientSecret,
+                    callbackURL: urlLib.getApi(config.passport.google.callbackUrl),
+                    userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
+                    passReqToCallback: true // http://passportjs.org/guide/authorize/#association_in_verify_callback
+                },
+                async function (req, accessToken, refreshToken, profile, done) {
+                    logger.debug('Google responded with profile: ', profile);
 
-                try {
-                    const user = await _findOrCreateUser(UserConnection.CONNECTION_IDS.google, User.SOURCES.google, profile, req);
+                    try {
+                        const user = await _findOrCreateUser(UserConnection.CONNECTION_IDS.google, User.SOURCES.google, profile, req);
 
-                    return done(null, user.toJSON());
-                } catch (err) {
-                    console.log(err);
-                    done(err);
+                        return done(null, user.toJSON());
+                    } catch (err) {
+                        console.log(err);
+                        done(err);
+                    }
                 }
-            }
-        ));
+            ));
+        }
 
         // FACEBOOK
-        passport.use(new FacebookStrategy(
-            {
-                clientID: config.passport.facebook.clientId,
-                clientSecret: config.passport.facebook.clientSecret,
-                callbackURL: urlLib.getApi(config.passport.facebook.callbackUrl),
-                enableProof: false,
-                profileFields: ['id', 'displayName', 'cover', 'email'],
-                passReqToCallback: true
-            },
-            async function (req, accessToken, refreshToken, profile, done) {
-                logger.info('Facebook responded with profile: ', profile);
-                try {
-                    const user = await _findOrCreateUser(UserConnection.CONNECTION_IDS.facebook, User.SOURCES.facebook, profile, req);
+	if (passport.facebook) {
+            passport.use(new FacebookStrategy(
+                {
+                    clientID: config.passport.facebook.clientId,
+                    clientSecret: config.passport.facebook.clientSecret,
+                    callbackURL: urlLib.getApi(config.passport.facebook.callbackUrl),
+                    enableProof: false,
+                    profileFields: ['id', 'displayName', 'cover', 'email'],
+                    passReqToCallback: true
+                },
+                async function (req, accessToken, refreshToken, profile, done) {
+                    logger.info('Facebook responded with profile: ', profile);
+                    try {
+                        const user = await _findOrCreateUser(UserConnection.CONNECTION_IDS.facebook, User.SOURCES.facebook, profile, req);
 
-                    return done(null, user.toJSON());
-                } catch (err) {
-                    console.log(err);
-                    done(err);
+                        return done(null, user.toJSON());
+                    } catch (err) {
+                        console.log(err);
+                        done(err);
+                    }
                 }
-            }
-        ));
+            ));
+        }
 
         // LOCAL
         passport.use(new LocalStrategy(

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -887,55 +887,58 @@ module.exports = function (app) {
     };
 
 
-    // Passport endpoints
-    app.get(config.passport.google.url, function (req, res, next) {
-        // Store original request in a cookie, so that we know where to redirect back on callback from the partner (FB, Google...)
-        setStateCookie(req, res, COOKIE_NAME_COS_AUTH_STATE);
+    if (config.passport.google) {
+        // Passport endpoints
+        app.get(config.passport.google.url, function (req, res, next) {
+            // Store original request in a cookie, so that we know where to redirect back on callback from the partner (FB, Google...)
+            setStateCookie(req, res, COOKIE_NAME_COS_AUTH_STATE);
 
-        passport.authenticate('google', {
-            scope: ['https://www.googleapis.com/auth/userinfo.email'],
-            prompt: 'select_account',
-            keepSessionInfo: true
-        })(req, res, next);
-    });
-
-
-    app.get(
-        config.passport.google.callbackUrl,
-        passport.authenticate('google', {
-            failureRedirect: urlLib.getFe('/account/login'),
-            keepSessionInfo: true
-        }),
-        function (req, res) {
-            setAuthCookie(req, res, req.user.id);
-            handleCallbackRedirect(req, res);
-        }
-    );
+            passport.authenticate('google', {
+                scope: ['https://www.googleapis.com/auth/userinfo.email'],
+                prompt: 'select_account',
+                keepSessionInfo: true
+            })(req, res, next);
+        });
 
 
-    app.get(config.passport.facebook.url, function (req, res, next) {
-        // Store original request in a cookie, so that we know where to redirect back on callback from the partner (FB, Google...)
-        setStateCookie(req, res, COOKIE_NAME_COS_AUTH_STATE);
+        app.get(
+            config.passport.google.callbackUrl,
+            passport.authenticate('google', {
+                failureRedirect: urlLib.getFe('/account/login'),
+                keepSessionInfo: true
+            }),
+            function (req, res) {
+                setAuthCookie(req, res, req.user.id);
+                handleCallbackRedirect(req, res);
+            }
+        );
+    }
 
-        passport.authenticate('facebook', {
-            scope: ['email'],
-            keepSessionInfo: true,
-            display: req.query.display ? 'popup' : null
-        })(req, res, next);
-    });
+    if (config.passport.google) {
+        app.get(config.passport.facebook.url, function (req, res, next) {
+            // Store original request in a cookie, so that we know where to redirect back on callback from the partner (FB, Google...)
+            setStateCookie(req, res, COOKIE_NAME_COS_AUTH_STATE);
+
+            passport.authenticate('facebook', {
+                scope: ['email'],
+                keepSessionInfo: true,
+                display: req.query.display ? 'popup' : null
+            })(req, res, next);
+        });
 
 
-    app.get(
-        config.passport.facebook.callbackUrl,
-        passport.authenticate('facebook', {
-            failureRedirect: urlLib.getFe('/account/login'),
-            keepSessionInfo: true
-        }),
-        function (req, res) {
-            setAuthCookie(req, res, req.user.id);
-            handleCallbackRedirect(req, res);
-        }
-    );
+        app.get(
+            config.passport.facebook.callbackUrl,
+            passport.authenticate('facebook', {
+                failureRedirect: urlLib.getFe('/account/login'),
+                keepSessionInfo: true
+            }),
+            function (req, res) {
+                setAuthCookie(req, res, req.user.id);
+                handleCallbackRedirect(req, res);
+            }
+        );
+    }
 
 
     /**


### PR DESCRIPTION
When configuration for external authentication (facebook, google, smartId, mobileId) was omitted, the code would fail to start. This adds some checks and skips initialization of these external authentication providers, allowing to start without any of them.

Note that the these authentication providers should seperatelly be disabled in the frontend config.

This diff is best viewed with `--ignore-all-space`.