### PR TITLE
FIX building with --exclude dev by making husky non-dev dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,6 +37,7 @@
         "fs-extra": "11.2.0",
         "html-entities": "2.5.2",
         "htmlparser2": "9.1.0",
+        "husky": "9.1.2",
         "image-size": "1.1.1",
         "json-patch-gen": "1.0.2",
         "jsonwebtoken": "9.0.2",
@@ -92,7 +93,6 @@
         "grunt-eslint": "25.0.0",
         "grunt-exec": "3.0.0",
         "grunt-plantuml": "1.0.3",
-        "husky": "9.1.2",
         "mocha": "10.7.0",
         "supertest": "7.0.0"
       },
@@ -10858,7 +10858,6 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.2.tgz",
       "integrity": "sha512-1/aDMXZdhr1VdJJTLt6e7BipM0Jd9qkpubPiIplon1WmCeOy3nnzsCMeBqS9AsL5ioonl8F8y/F2CLOmk19/Pw==",
-      "dev": true,
       "bin": {
         "husky": "bin.js"
       },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "fs-extra": "11.2.0",
     "html-entities": "2.5.2",
     "htmlparser2": "9.1.0",
+    "husky": "9.1.2",
     "image-size": "1.1.1",
     "json-patch-gen": "1.0.2",
     "jsonwebtoken": "9.0.2",
@@ -101,7 +102,6 @@
     "grunt-eslint": "25.0.0",
     "grunt-exec": "3.0.0",
     "grunt-plantuml": "1.0.3",
-    "husky": "9.1.2",
     "mocha": "10.7.0",
     "supertest": "7.0.0"
   },


### PR DESCRIPTION
WIthout this commit, `npm install --exclude dev`  fails with:

	140.7 > citizenos-api@5.0.6 prepare
	140.7 > husky
	140.7
	140.7 sh: husky: not found

Moving husky from dev to normal dependencies fixes this.