### PR TITLE
Unhardcode mail addresses

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -100,6 +100,8 @@
       }
     },
     "from": "Citizen OS <no-reply@citizenos.com>",
+    "supportTo": "support@citizenos.com",
+    "feedbackTo": "support@citizenos.com",
     "linkToPrivacyPolicy": "https://app.citizenos.com/en/topics/7abdd244-d45b-40d3-997c-a6290d4e972c",
     "linkViewModerationGuidelines": "https://app.citizenos.com/en/topics/ac8b66a4-ca56-4d02-8406-5e19da73d7ce",
     "trap": false,

--- a/libs/email.js
+++ b/libs/email.js
@@ -343,7 +343,6 @@ module.exports = function (app) {
                 subject: 'Help request',
                 to: [config.email.supportTo],
                 replyTo: debugData.email,
-                from: "no-reply@citizenos.com",
                 linkedData: {
                     translations: template.translations,
                 },
@@ -370,7 +369,6 @@ module.exports = function (app) {
             {
                 subject: 'Feedback',
                 to: [config.email.feedbackTo],
-                from: "no-reply@citizenos.com",
                 linkedData: {
                     translations: template.translations,
                 },
@@ -410,7 +408,6 @@ module.exports = function (app) {
                 {
                     subject: template.translations.ACCOUNT_VERIFICATION.SUBJECT,
                     to: user.email,
-                    from: "no-reply@citizenos.com",
                     //Placeholders
                     toUser: user,
                     linkVerify: linkVerify
@@ -450,7 +447,6 @@ module.exports = function (app) {
                 {
                     subject: template.translations.PASSWORD_RESET.SUBJECT,
                     to: user.email,
-                    from: "no-reply@citizenos.com",
                     //Placeholders..
                     toUser: user,
                     linkReset: urlLib.getFe('/account/password/reset/:passwordResetCode', { passwordResetCode: passwordResetCode }, { email: user.email })

--- a/libs/email.js
+++ b/libs/email.js
@@ -341,7 +341,7 @@ module.exports = function (app) {
             _.cloneDeep(EMAIL_OPTIONS_DEFAULT), // Deep clone to guarantee no funky business messing with the class level defaults, cant use Object.assign({}.. as this is not a deep clone.
             {
                 subject: 'Help request',
-                to: ['support@citizenos.com'],
+                to: [config.email.supportTo],
                 replyTo: debugData.email,
                 from: "no-reply@citizenos.com",
                 linkedData: {
@@ -369,7 +369,7 @@ module.exports = function (app) {
             _.cloneDeep(EMAIL_OPTIONS_DEFAULT), // Deep clone to guarantee no funky business messing with the class level defaults, cant use Object.assign({}.. as this is not a deep clone.
             {
                 subject: 'Feedback',
-                to: ['support@citizenos.com'],
+                to: [config.email.feedbackTo],
                 from: "no-reply@citizenos.com",
                 linkedData: {
                     translations: template.translations,


### PR DESCRIPTION
This makes two changes that prevent hardcoding `@citizenos.com` e-mail addresses in the source code, both in the `from` addresses for all mails (making the existing config option for this work) and for the `to` addresses for help requests and feedback mails (this adds two new configuration directives).

I have tested this on a self-hosted install for the help form. I could not find the feedback form to also test that path (the code suggests that that might be triggered via etherpad, and I have not fully set up the etherpad integration yet).