### PR TITLE
Add disable replies to ideas setting to ideation

### DIFF
--- a/db/migrations/20250108215519-alter-ideation-disable-replies.js
+++ b/db/migrations/20250108215519-alter-ideation-disable-replies.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return queryInterface.addColumn('Ideations', 'disableReplies', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        comment: 'Disable replies'
+      }, { transaction: t })
+    })
+  },
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction((t) => {
+      return queryInterface.removeColumn('Ideations', 'disableReplies', { transaction: t })
+    })
+  }
+};

--- a/db/models/Ideation.js
+++ b/db/models/Ideation.js
@@ -47,6 +47,12 @@ module.exports = function (sequelize, Sequelize) {
                     }
                 }
             },
+            disableReplies: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+                comment: 'Disable replies'
+            },
             createdAt: {
                 allowNull: false,
                 type: Sequelize.DATE
@@ -89,6 +95,7 @@ module.exports = function (sequelize, Sequelize) {
             question: this.dataValues.question,
             creatorId: this.dataValues.creatorId,
             deadline: this.dataValues.deadline,
+            disableReplies: this.dataValues.disableReplies,
             createdAt: this.dataValues.createdAt,
             updatedAt: this.dataValues.updatedAt
         };

--- a/routes/api/ideation.js
+++ b/routes/api/ideation.js
@@ -46,6 +46,8 @@ module.exports = function (app) {
         const question = req.body.question;
         const deadline = req.body.deadline;
         const topicId = req.params.topicId;
+        const disableReplies = req.body.disableReplies;
+
         try {
             if (!question) {
                 return res.badRequest('Ideation question is missing', 1);
@@ -54,6 +56,7 @@ module.exports = function (app) {
             const ideation = Ideation.build({
                 question,
                 deadline,
+                disableReplies,
                 creatorId: req.user.id
             });
 
@@ -134,6 +137,7 @@ module.exports = function (app) {
                     i.id,
                     i.question,
                     i.deadline,
+                    i."disableReplies",
                     i."creatorId",
                     i."createdAt",
                     i."updatedAt",
@@ -383,7 +387,7 @@ module.exports = function (app) {
         try {
             const topicId = req.params.topicId;
             const ideationId = req.params.ideationId;
-            let fields = ['deadline', 'question'];
+            let fields = ['deadline', 'question', 'disableReplies'];
 
             const topic = await Topic.findOne({
                 where: {
@@ -398,7 +402,7 @@ module.exports = function (app) {
                     }
                 ]
             });
-            if (!topic || !topic.Ideations || !topic.Ideations.length) {
+            if (!topic?.Ideations?.length) {
                 return res.notFound();
             }
             if (topic.status === Topic.STATUSES.draft) {
@@ -432,6 +436,7 @@ module.exports = function (app) {
                         i.id,
                         i.question,
                         i.deadline,
+                        i."disableReplies",
                         i."creatorId",
                         i."createdAt",
                         i."updatedAt",
@@ -534,7 +539,7 @@ module.exports = function (app) {
                 ]
             });
 
-            if (!ideation || !ideation.Topics.length) {
+            if (!ideation?.Topics?.length) {
                 return res.notFound();
             }
             if (ideation.deadline && new Date(ideation.deadline) < new Date()) return res.forbidden();
@@ -743,7 +748,7 @@ module.exports = function (app) {
                     }
                 ]
             });
-            if (!ideation || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -1085,7 +1090,7 @@ module.exports = function (app) {
                 ]
             });
 
-            if (!ideation || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -1124,7 +1129,7 @@ module.exports = function (app) {
                 ]
             });
 
-            if (!ideation || !ideation.Topics.length) {
+            if (!ideation?.Topics?.length) {
                 return res.notFound();
             }
 
@@ -1187,7 +1192,7 @@ module.exports = function (app) {
                     },
                 ]
             });
-            if (!ideation || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -1252,7 +1257,7 @@ module.exports = function (app) {
                     },
                 ]
             });
-            if (!ideation || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -1347,7 +1352,7 @@ module.exports = function (app) {
                     },
                 ]
             });
-            if (!ideation || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -1387,7 +1392,7 @@ module.exports = function (app) {
                 }
             ]
         });
-        if (!ideation || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+        if (!ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
             return res.notFound();
         }
 
@@ -1724,7 +1729,7 @@ module.exports = function (app) {
                 ]
             });
 
-            if (!ideation || !ideation.Ideas.length || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Ideas?.length || !ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -1800,7 +1805,7 @@ module.exports = function (app) {
                 ]
             });
 
-            if (!ideation || !ideation.Ideas.length || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Ideas?.length || !ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -1877,7 +1882,7 @@ module.exports = function (app) {
             ]
         });
 
-        if (!ideation || !ideation.Ideas.length || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+        if (!ideation?.Ideas?.length || !ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
             return res.notFound();
         }
 
@@ -1976,7 +1981,7 @@ module.exports = function (app) {
                 ]
             });
 
-            if (!ideation || !ideation.Topics.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
+            if (!ideation?.Topics?.length || ideation.Topics[0].visbility === Topic.VISIBILITY.private) {
                 return res.notFound();
             }
 
@@ -2289,6 +2294,14 @@ module.exports = function (app) {
      */
     app.post('/api/users/:userId/topics/:topicId/ideations/:ideationId/ideas/:ideaId/comments', loginCheck(['partner']), topicLib.hasPermission(TopicMemberUser.LEVELS.read, true), async (req, res, next) => {
         try {
+            const ideation = await Ideation.findOne({
+                where: {
+                    id: req.params.ideationId
+                }
+            });
+            if (ideation?.disableReplies) {
+                return res.forbidden('Replies are disabled for this ideation');
+            }
             let type = req.body.type || Comment.TYPES.reply;
             const parentId = req.body.parentId;
             const topicId = req.params.topicId;
@@ -2339,7 +2352,6 @@ module.exports = function (app) {
                         });
                     }
                     await comment.save({ transaction: t });
-                    //comment.edits.createdAt = JSON.stringify(comment.createdAt);
                     const idea = await Idea.findOne({
                         where: {
                             id: req.params.ideaId
@@ -2813,9 +2825,9 @@ module.exports = function (app) {
     app.get('/api/topics/:topicId/ideations/:ideationId/ideas/:ideaId/comments', topicLib.hasVisibility(Topic.VISIBILITY.public), topicLib.isModerator(), ideaCommentsList);
 
     /**
-     * Delete Topic Comment
+     * Delete Idea Comment
      */
-    app.delete('/api/users/:userId/topics/:topicId/ideations/:ideationId/ideas/:ideaId/comments/:commentId', loginCheck(['partner']), discussionLib.isCommentCreator(), topicLib.hasPermission(TopicMemberUser.LEVELS.admin, false, null, true));
+    app.delete('/api/users/:userId/topics/:topicId/ideations/:ideationId/ideas/:ideaId/comments/:commentId', loginCheck(['partner']), discussionLib.isCommentCreator(), topicLib.hasPermission(TopicMemberUser.LEVELS.read, false, null, true));
 
     //WARNING: Don't mess up with order here! In order to use "next('route')" in the isCommentCreator, we have to have separate route definition
     //NOTE: If you have good ideas how to keep one route definition with several middlewares, feel free to share!
@@ -2896,7 +2908,6 @@ module.exports = function (app) {
                 createdAt: now,
                 type: type
             });
-            comment.set('edits', null);
             comment.set('edits', edits);
             comment.subject = subject;
             comment.text = text;
@@ -3057,7 +3068,7 @@ module.exports = function (app) {
                     }
                 );
 
-            if (!results || !results.length) {
+            if (!results?.length) {
                 return res.notFound();
             }
 

--- a/test/api/ideation.js
+++ b/test/api/ideation.js
@@ -1170,6 +1170,19 @@ suite('Users', function () {
                 assert.deepEqual(ideationUpdated, ideationR);
             });
 
+            test('Success - disableReplies when topic status ideation', async function () {
+                const topic = (await topicLib.topicCreate(agent, user.id, null, null, null, Topic.VISIBILITY.private)).body.data;
+                const ideation = (await ideationCreate(agent, user.id, topic.id, 'TEST ideation', null, true)).body.data;
+                await topicLib.topicUpdate(agent, user.id, topic.id, Topic.STATUSES.ideation);
+                const idea = (await ideationIdeaCreate(agent, user.id, topic.id, ideation.id, 'TEST', 'TEST')).body.data;
+                await _ideationIdeaCommentCreate(agent, user.id, topic.id, ideation.id, idea.id, null, null, Comment.TYPES.pro, 'TEST', 'TEST', 403);
+                const ideationUpdated = (await ideationUpdate(agent, user.id, topic.id, ideation.id, null, null, false)).body.data;
+                await ideationIdeaCommentCreate(agent, user.id, topic.id, ideation.id, idea.id, null, null, Comment.TYPES.pro, 'TEST2', 'TEST2');
+                const ideationR = (await ideationRead(agent, user.id, topic.id, ideation.id)).body.data;
+                // The difference from create result is that there is "members" and "creator" is extended. Might consider changing in the future..
+                assert.deepEqual(ideationUpdated, ideationR);
+            });
+
             test('Fail - deadline in the past', async function () {
                 const deadline = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
                 const errors = (await _ideationUpdate(agent, user.id, topic.id, ideation.id, undefined, deadline, null, 400)).body.errors;


### PR DESCRIPTION
How to test:
- run database migration `npm run dbmigrate`
- run tests related to Ideation `NODE_ENV=test FORCE_DB_SYNC=1 NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/.bin/mocha --expose-gc --async-only --check-leaks --trace-deprecation --no-timeouts --reporter spec --no-exit --recursive --ui tdd --grep 'Ideation test/`

Expected:
- All tests should pass