### PR TITLE
Public topics not showing up as added to public group [#1656]

### DIFF
--- a/routes/api/topic.js
+++ b/routes/api/topic.js
@@ -3538,10 +3538,7 @@ module.exports = function (app) {
                     SELECT mg.*,count(*) OVER()::integer AS "countTotal" FROM (
                         SELECT
                             g.id,
-                            CASE
-                                WHEN gmu.level IS NOT NULL THEN g.name
-                                ELSE NULL
-                            END as "name",
+                            g.name,
                             g."createdAt",
                             g."updatedAt",
                             tmg.level,


### PR DESCRIPTION
Steps to test:
- authenticate with user
- go to any topic, which attached to some groups, but your user is not a member of this group

Current:
- group "name" field is empty

Expected:
- show group name

> Note: @ilmartyrk Please check potential side effects. I cannot understand why endpoint has such logic on query level, so please double check. If there are side effects, then I still think we should return group name with the query, but the we need to fix side effects.