### PR TITLE
Feature: Demographic fields configuration [#1865]

### DIFF
--- a/db/migrations/20250212225513-alter-ideation-add-demographic-config.js
+++ b/db/migrations/20250212225513-alter-ideation-add-demographic-config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return queryInterface.addColumn(
+        "Ideations",
+        "demographicsConfig",
+        {
+          type: Sequelize.JSONB,
+          allowNull: true,
+          comment: "Idea demographics fields configuration",
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn("Ideations", "demographicsConfig", {
+          transaction: t,
+        }),
+      ]);
+    });
+  },
+};

--- a/db/migrations/20250215165905-alter-ideaa-add-demographics-fields.js
+++ b/db/migrations/20250215165905-alter-ideaa-add-demographics-fields.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return queryInterface.addColumn(
+        "Ideas",
+        "demographics",
+        {
+          type: Sequelize.JSONB,
+          allowNull: true,
+          comment: "Idea demographics fields",
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn("Ideas", "demographics", {
+          transaction: t,
+        }),
+      ]);
+    });
+  },
+};

--- a/db/models/Idea.js
+++ b/db/models/Idea.js
@@ -110,6 +110,12 @@ module.exports = function (sequelize, DataTypes) {
                 onUpdate: 'CASCADE',
                 onDelete: 'CASCADE'
             },
+            demographics: {
+                type: DataTypes.JSONB,
+                allowNull: true,
+                defaultValue: null,
+                comment: 'Demographics fields'
+            },
             createdAt: {
                 allowNull: false,
                 type: DataTypes.DATE
@@ -138,7 +144,7 @@ module.exports = function (sequelize, DataTypes) {
             updatedAt: this.dataValues.updatedAt,
             deletedAt: this.dataValues.deletedAt,
             deletedReasonType: this.dataValues.deletedReasonType,
-            deletedReasonText: this.dataValues.deletedReasonText
+            deletedReasonText: this.dataValues.deletedReasonText,
         };
 
 
@@ -162,6 +168,10 @@ module.exports = function (sequelize, DataTypes) {
         } else {
             data.report = {};
             data.report.id = this.dataValues.deletedByReportId;
+        }
+
+        if(this.dataValues.demographics) {
+            data.demographics = this.dataValues.demographics;
         }
 
         return data;

--- a/db/models/Ideation.js
+++ b/db/models/Ideation.js
@@ -1,4 +1,7 @@
 'use strict';
+
+const { DataTypes } = require("sequelize");
+
 /**
  * Ideation
  *
@@ -65,6 +68,12 @@ module.exports = function (sequelize, Sequelize) {
                 defaultValue: null,
                 comment: 'Allow idea template'
             },
+            demographicsConfig: {
+                type: DataTypes.JSONB,
+                allowNull: true,
+                defaultValue: null,
+                comment: 'Configuration for demographics data fields'
+            },
             createdAt: {
                 allowNull: false,
                 type: Sequelize.DATE
@@ -110,6 +119,7 @@ module.exports = function (sequelize, Sequelize) {
             disableReplies: this.dataValues.disableReplies,
             allowAnonymous: this.dataValues.allowAnonymous,
             template: this.dataValues.template,
+            demographics: this.dataValues.demographics,
             createdAt: this.dataValues.createdAt,
             updatedAt: this.dataValues.updatedAt
         };

--- a/libs/cosActivities.js
+++ b/libs/cosActivities.js
@@ -148,6 +148,14 @@ module.exports = function (app) {
             currentValues[field] = instance.dataValues[field];
         });
 
+        // diff cannot compare object states properly when
+        // previousValues was null and the field type is JSON.
+        // For example, for ideation/demigpaphics field:
+        // TypeError: Cannot use 'in' operator to search for 'age' in null
+        if (previousValues.demographicsConfig === null) {
+            previousValues.demographicsConfig = {}
+        }
+
         // Diff is only performed for JSON objects, thus if we put regular JS objects to it, it MAY result in invalid results
         // For example Date comparisons will fail if both sides have a Date object.
         const previousValuesJson = JSON.parse(JSON.stringify(previousValues));

--- a/routes/api/activity.js
+++ b/routes/api/activity.js
@@ -194,7 +194,16 @@ module.exports = function (app) {
         return includedSql.join(' UNION ');
     };
 
-    const parseActivitiesResults = function (activities) {
+    const parseActivitiesResults = function (allActivities) {
+        /**
+         * @note Since we have no anonymous ideas, there are nullable values about actor.
+         * We should be aware of it and filter out the null values.
+         *
+         * @todo Think of how to handle anonymous ideas.
+         * @todo Think of how to move this to the SQL query.
+        */
+        const activities = allActivities.filter((it) => it.data.actor.id !== null)
+
         const returnList = [];
         activities.forEach(function (activity) {
             const returnActivity = _.cloneDeep(activity);
@@ -1174,7 +1183,7 @@ module.exports = function (app) {
                             }
                         });
                     }
-                    //              console.log(`${query} ${selectSql}`)
+
                     const results = await db
                         .query(`${query} ${selectSql}`,
                             {
@@ -1198,7 +1207,7 @@ module.exports = function (app) {
                                 t
                             );
                     }
-                    //          console.log(results);
+                    
                     const finalResults = parseActivitiesResults(results);
 
                     t.afterCommit(() => {

--- a/routes/api/ideation.js
+++ b/routes/api/ideation.js
@@ -542,7 +542,7 @@ module.exports = function (app) {
         const statement = req.body.statement;
         const description = req.body.description;
         const imageUrl = req.body.imageUrl;
-        const demographicsConfig = req.body.demographicsConfig;
+        const demographics = req.body.demographics;
 
         try {
 
@@ -577,8 +577,9 @@ module.exports = function (app) {
                         description,
                         imageUrl,
                         ideationId,
-                        demographicsConfig
+                        demographics
                     });
+                    console.log(idea, "hdsgahgdfashgdfashgdfasgdfg")
                     idea.topicId = topicId;
                     await idea.save({ transaction: t });
 

--- a/routes/api/ideation.js
+++ b/routes/api/ideation.js
@@ -62,6 +62,7 @@ module.exports = function (app) {
                 allowAnonymous,
                 disableReplies,
                 template: req.body.template,
+                demographics: req.body.demographicsConfig,
             });
 
 
@@ -147,6 +148,7 @@ module.exports = function (app) {
                     i."updatedAt",
                     i."allowAnonymous",
                     i."template",
+                    i."demographicsConfig",
                     COALESCE(ii.count, 0) as "ideas.count",
                     COALESCE(fi.count, 0) as "folders.count"
                 FROM "Ideations" i
@@ -393,7 +395,7 @@ module.exports = function (app) {
         try {
             const topicId = req.params.topicId;
             const ideationId = req.params.ideationId;
-            let fields = ['deadline', 'disableReplies', 'template'];
+            let fields = ['deadline', 'disableReplies', 'template', 'demographicsConfig'];
 
             const topic = await Topic.findOne({
                 where: {
@@ -451,6 +453,7 @@ module.exports = function (app) {
                         i."disableReplies",
                         i."allowAnonymous",
                         i."template",
+                        i."demographicsConfig",
                         i."creatorId",
                         i."createdAt",
                         i."updatedAt",
@@ -539,6 +542,7 @@ module.exports = function (app) {
         const statement = req.body.statement;
         const description = req.body.description;
         const imageUrl = req.body.imageUrl;
+        const demographicsConfig = req.body.demographicsConfig;
 
         try {
 
@@ -572,7 +576,8 @@ module.exports = function (app) {
                         statement,
                         description,
                         imageUrl,
-                        ideationId
+                        ideationId,
+                        demographicsConfig
                     });
                     idea.topicId = topicId;
                     await idea.save({ transaction: t });

--- a/routes/api/ideation.js
+++ b/routes/api/ideation.js
@@ -579,7 +579,6 @@ module.exports = function (app) {
                         ideationId,
                         demographics
                     });
-                    console.log(idea, "hdsgahgdfashgdfashgdfasgdfg")
                     idea.topicId = topicId;
                     await idea.save({ transaction: t });
 


### PR DESCRIPTION
## Description

In order to store demographic fields for anonymous ideas, we need to have additional fields for:
- `ideation` table
  - demographicsConfig: `Record<string, { required: boolean; value?: string }> | null`
- `idea` table
  - demographics: `Record<string, string> | null`

`demographicsConfig` holds possible fields admin wants to collect in idea. For example:
```
age: {
    required: true
},
....
```

Then when creating the idea user have to provide age info. Then it is stored in `demographics` as:
```
{ "age": "23", ... }
```