### PR TITLE
Chore: Remove extra check when request for topic invite [#1908]

### DIFF
--- a/routes/api/topic.js
+++ b/routes/api/topic.js
@@ -4957,8 +4957,6 @@ module.exports = function (app) {
 
         if (!topic) {
             return res.notFound();
-        } else if (topic.visibility === Topic.VISIBILITY.private && !topicMember) {
-            return res.ok({ title: topic.title });
         }
         topic = topic.toJSON();
         if (topicMember && topicMember.length) {


### PR DESCRIPTION
## Description

In order to show extra details for invitation dialog for private topic, we need to return full invitation object

> Note: @ilmartyrk is there any restriction why I cannot remove this extra check for private topic?