### PR TITLE
Fix: Invitation dialog for private topic [#1930]

### DIFF
--- a/routes/api/topic.js
+++ b/routes/api/topic.js
@@ -4580,7 +4580,7 @@ module.exports = function (app) {
                     include: [
                         {
                             model: Topic,
-                            attributes: ['id', 'title', 'visibility', 'creatorId'],
+                            attributes: ['id', 'title', 'visibility', 'creatorId', 'imageUrl', 'intro', 'description'],
                             as: 'topic',
                             required: true
                         },


### PR DESCRIPTION
Steps to test:
- send invitation to any topic on email
- follow link in the email

Current:
- no image/description in popup

Expected:
- image/description in popup