### PR TITLE
Fix: Removing image leads to a forbidden error [#2029]

### DIFF
--- a/routes/api/ideation.js
+++ b/routes/api/ideation.js
@@ -3971,7 +3971,13 @@ module.exports = function (app) {
             const [attachment, ideation] = await Promise.all([attachmentPromise, ideationPromise]);
             const idea = attachment.Ideas[0];
 
-            if ((ideation.allowAnonymous && idea.sessionId !== sessToken) || (!ideation.allowAnonymous && req.user.id !== req.params.userId)) {
+            const user = await User.findOne({
+                where: {
+                    id: req.user.userId
+                }
+            });
+
+            if ((ideation.allowAnonymous && idea.sessionId !== sessToken) || (!ideation.allowAnonymous && req.user.id !== user.id)) {
                 return res.forbidden();
             }
 


### PR DESCRIPTION
## Description

It appears that previously we compared "uuid" with "self" value in this kind of equation: `req.user.id !== userId`

We need to query user object first to get proper user id