### PR TITLE
Fix: Draft idea sessionId creation [#2016]

### DIFF
--- a/routes/api/ideation.js
+++ b/routes/api/ideation.js
@@ -591,7 +591,7 @@ module.exports = function (app) {
 
                     const idea = Idea.build({
                         authorId: (ideation.allowAnonymous && status !== 'draft') ? null : req.user.id,
-                        sessionId: (ideation.allowAnonymous && status !== 'draft') ? sessToken : null,
+                        sessionId: (ideation.allowAnonymous && status !== 'draft') ? null : sessToken,
                         statement,
                         description,
                         imageUrl,


### PR DESCRIPTION
## Description

When delete the idea it looks for sessionId and for draft ideas it was not created by purpose. However, later on, when updating idea (app.put), it is creating sessionId for anon ideas, so, looks like we can create sessionId for draft ideas from beginning

> Note: @ilmartyrk can you please review the solution for side effects