### PR TITLE
Fix: Images not added to anonymous ideas [#2087]

### DIFF
--- a/db/migrations/20250415183735-alter-attachments-update-creator-id-relation.js
+++ b/db/migrations/20250415183735-alter-attachments-update-creator-id-relation.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE "Attachments" ALTER COLUMN "creatorId" DROP NOT NULL;'
+    );
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE "Attachments" ALTER COLUMN "creatorId" SET NOT NULL;'
+    );
+  },
+};

--- a/db/models/Attachment.js
+++ b/db/models/Attachment.js
@@ -79,7 +79,7 @@ module.exports = function (sequelize, DataTypes) {
         Attachment.belongsTo(models.User, {
             foreignKey: {
                 fieldName: 'creatorId',
-                allowNull: false
+                allowNull: true
             },
             as: 'creator'
         });

--- a/routes/api/ideation.js
+++ b/routes/api/ideation.js
@@ -3702,9 +3702,6 @@ module.exports = function (app) {
             if (!ideation.allowAnonymous && idea.authorId !== req.user.id) {
                 return res.forbidden();
             }
-            if (ideation.allowAnonymous && idea.status !== 'draft' && idea.sessionId !== sessToken) {
-                return res.forbidden();
-            }
             if (!idea) {
                 return res.badRequest('Matching idea not found', 3);
             }


### PR DESCRIPTION
- add migration to make creatorId not nullable (make migration as pure sql cause somehow sequalize didn't work out, maybe cache or so..)
- remove extra check preventing images creation